### PR TITLE
Fix: use debian:stable-slim for Docker images using can-utils.

### DIFF
--- a/can-utils-sh/Dockerfile
+++ b/can-utils-sh/Dockerfile
@@ -1,5 +1,4 @@
 # Copyright Alexander Entinger, MSc / LXRobotics GmbH
 # This docker file allows building and running of a container which dumps all received CAN frames on `stdout`.
-FROM alpine:3.18
-
-RUN apk add can-utils
+FROM debian:stable-slim
+RUN apt update && apt install can-utils -y

--- a/candump/Dockerfile
+++ b/candump/Dockerfile
@@ -1,5 +1,4 @@
 # Copyright Alexander Entinger, MSc / LXRobotics GmbH
 # This docker file allows building and running of a container which dumps all received CAN frames on `stdout`.
-FROM alpine:3.18
-
-RUN apk add can-utils
+FROM debian:stable-slim
+RUN apt update && apt install can-utils -y


### PR DESCRIPTION
Apparently there's some problem with can-utils within alpine.