### PR TITLE
Fix: compile DSDL during "docker build".

### DIFF
--- a/yakut-can/docker-run.sh
+++ b/yakut-can/docker-run.sh
@@ -66,4 +66,10 @@ sudo -u fio ifconfig $CAN
 echo "CAN_MTU     = $CAN_MTU"
 echo "CAN_NODE_ID = $CAN_NODE_ID"
 
-sudo -u fio sudo docker run -it -u 0 --network host pika_spark_yakut_can yakut --transport "CAN(can.media.socketcan.SocketCANMedia('$CAN',$CAN_MTU),$CAN_NODE_ID)" monitor
+COMPILED_DSDL_PATH="/home/fio/.pycyphal"
+
+if [ ! -d $COMPILED_DSDL_PATH ]; then
+  mkdir $COMPILED_DSDL_PATH
+fi
+
+sudo -u fio sudo docker run -it -u 0 --network host -v $COMPILED_DSDL_PATH:$COMPILED_DSDL_PATH pika_spark_yakut_can yakut --transport "CAN(can.media.socketcan.SocketCANMedia('$CAN',$CAN_MTU),$CAN_NODE_ID)" monitor


### PR DESCRIPTION
Currently it compiles the DSDL every-time we run the container, which is time consuming and unpleasant.

The only problem is, that it seems as if `yakut compile` is discouraged, see https://github.com/OpenCyphal/yakut/commit/d7fed7179e2de2ae9e0945f50152c7fc2e397dd6 .

@pavel-kirienko - do you have a better idea?